### PR TITLE
Make it possible to set per-layer connection timeout

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -26,6 +26,7 @@ DEFAULT_THEME_NAME = "Default"
 
 LOCATION_TIMEOUT = 30 # in seconds
 INTERNET_CONNECTIVITY_TIMEOUT = 30 # in seconds
+TILE_DOWNLOAD_TIMEOUT = 10 # in seconds
 
 ONLINE = True
 OFFLINE = False

--- a/core/layers.py
+++ b/core/layers.py
@@ -119,6 +119,26 @@ class MapLayer(object):
             return tile_timeout
 
     @property
+    def connection_timeout(self):
+        """How long should we wait for tile to be download for this layer.
+        
+        This can be of a bigger importance for local host tile rendering
+        servers that might take longer to render a tile but unlike a remote
+        tile server that might never reply due to connection interruption
+        the local rendering tileserver should almost always eventually
+        send back the tile.
+
+        :returns: connection timeout (in seconds)
+        :rtype: int or None
+        """
+        tile_connection_timeout = self.config.get('connection_timeout', None)
+        if tile_connection_timeout is not None:
+            return int(tile_connection_timeout)
+        else:
+            return tile_connection_timeout
+
+
+    @property
     def dict(self):
         """ Return a dictionary representing the layer
 
@@ -136,7 +156,8 @@ class MapLayer(object):
             "coordinates" : self.coordinates,
             "group_id" : self.group_id,
             "icon" : self.icon,
-            "timeout" : self.timeout
+            "timeout" : self.timeout,
+            "connection_timeout" : self.connection_timeout
         }
 
     def __repr__(self):

--- a/data/default_configuration_files/map_config.conf
+++ b/data/default_configuration_files/map_config.conf
@@ -1,6 +1,6 @@
 ## this config file configures the available map layers
 
-revision=25 ## configuration file revision
+revision=26 ## configuration file revision
 
 ## new layers use OSM style coordinates by default
 
@@ -18,6 +18,7 @@ revision=25 ## configuration file revision
 ##  timeout=24 <- tiles older than the timeout interval (in hours)
 ##                will be refetched from the Internet instead of using
 ##                the locally available tile (optional)
+##  connection_timeout=10 <- how long to wait for a single tile to download
 
 ## !! PUT THE URL IN QUOTES !!
 ## -> escapes any special characters such as commas
@@ -669,6 +670,7 @@ revision=25 ## configuration file revision
   type=png
   max_zoom=18
   min_zoom=1
+  connection_timeout=-1
   folder_prefix=osmscout_server_1
   coordinates=web_mercator_substitution
   group="osmscout_server"
@@ -679,6 +681,7 @@ revision=25 ## configuration file revision
   type=png
   max_zoom=18
   min_zoom=1
+  connection_timeout=-1
   folder_prefix=osmscout_server_2
   coordinates=web_mercator_substitution
   group="osmscout_server"


### PR DESCRIPTION
Add the connection_timeout key for layer in the map
config file, which can be used to set the connection
timeout for tile downloads.

This is mostly needed for offline rendering localhost
tileservers, such as OSM Scout Server, which might
in some cases take some time to render a tile but will
still eventually return it.

Like this we can set a longer connection timeout for
layers provided by localhost renderers while keeping
a short connection timeout for online layers to allow
for quick recovery from connectivity issues.