### PR TITLE
add osmscout car basemap

### DIFF
--- a/data/default_configuration_files/map_config.conf
+++ b/data/default_configuration_files/map_config.conf
@@ -687,6 +687,28 @@ revision=27 ## configuration file revision
   coordinates=web_mercator_substitution
   group="osmscout_server"
 
+[[osmscout_car_day]]
+  label=OSM Scout Car Day
+  url="http://localhost:8553/v1/tile?style=car&daylight=1&z=${z}&x=${x}&y=${y}"
+  type=png
+  max_zoom=18
+  min_zoom=1
+  connection_timeout=-1
+  folder_prefix=osmscout_server_car_1
+  coordinates=web_mercator_substitution
+  group="osmscout_server"
+
+[[osmscout_car_night]]
+  label=OSM Scout Car Night
+  url="http://localhost:8553/v1/tile?style=car&daylight=0&z=${z}&x=${x}&y=${y}"
+  type=png
+  max_zoom=18
+  min_zoom=1
+  connection_timeout=-1
+  folder_prefix=osmscout_server_car_2
+  coordinates=web_mercator_substitution
+  group="osmscout_server"
+
 ## LL -> XY projection not yet working
 #[[cb_sec]]
 #  label=Sectional


### PR DESCRIPTION
This PR adds support for OSM Scout Server car basemap style. Its differs from the default one by promoting gas stations (and few other smaller differences)