### PR TITLE
add support for OSM Scout Server routing V2, fixes #207

### DIFF
--- a/core/routing_providers.py
+++ b/core/routing_providers.py
@@ -318,13 +318,11 @@ class OSMScoutServerRouting(RoutingProvider):
                 'locations': locations
             }
             queryUrl = OSM_SCOUT_SERVER_ROUTING_URL + "json=" + json.dumps(params)
-            print(queryUrl)
             reply = urlopen(queryUrl)
             
             if reply:
                 # json in Python 3 really needs it encoded like this
                 replyData = reply.read().decode("utf-8")
-                print(replyData)
                 jsonReply = json.loads(replyData)
                 if "API version" in jsonReply and jsonReply['API version'] == "libosmscout V1":
                     route = Way.from_osm_scout_json(jsonReply)


### PR DESCRIPTION
This PR adds support for V2 routing protocol allowing to use it with Valhalla and libosmscout routing responses.