### PR TITLE
set osmscout guide query to poitype

### DIFF
--- a/modules/mod_onlineServices/offline_providers.py
+++ b/modules/mod_onlineServices/offline_providers.py
@@ -124,7 +124,7 @@ class OSMScoutServerLocalSearch(POIProvider):
             term = term.encode("utf-8")
             params = {
                 'limit': maxResults,
-                'query': term,
+                'poitype': term,
                 'radius': radius,
                 'lat' : around.lat,
                 'lng' : around.lon


### PR DESCRIPTION
I am going to separate _poitype_ and _name_ in the _guide_ search of OSM Scout Server. The idea is to distinguish when the user wants to find a cafe by name or just any cafe. Updated API is at https://github.com/rinigus/osmscout-server#poi-search-near-a-reference-position

The idea is to extend type support via https://github.com/rinigus/geocoder-nlp/issues/37 and, for that, I would need to separate names and types in the query. 

Right now, I don't know how to add _name_ in modRana interface and maybe its not even needed yet. But stay tuned, it maybe needed in future when I finish the current cycle of updating the geocoder component.